### PR TITLE
Fixed warnings and updated podspec to build framework on pod install.

### DIFF
--- a/TesseractOCR/include/tesseract/genericvector.h
+++ b/TesseractOCR/include/tesseract/genericvector.h
@@ -335,7 +335,7 @@ inline bool LoadDataFromFile(const STRING& filename,
   size_t size = ftell(fp);
   fseek(fp, 0, SEEK_SET);
   // Pad with a 0, just in case we treat the result as a string.
-  data->init_to_size(size + 1, 0);
+  data->init_to_size((int) size + 1, 0);
   bool result = fread(&(*data)[0], 1, size, fp) == size;
   fclose(fp);
   return result;

--- a/TesseractOCR/include/tesseract/helpers.h
+++ b/TesseractOCR/include/tesseract/helpers.h
@@ -30,7 +30,7 @@
 
 // Remove newline (if any) at the end of the string.
 inline void chomp_string(char *str) {
-  int last_index = strlen(str) - 1;
+  int last_index = (int) strlen(str) - 1;
   while (last_index >= 0 &&
          (str[last_index] == '\n' || str[last_index] == '\r')) {
     str[last_index--] = '\0';

--- a/TesseractOCRiOS.podspec
+++ b/TesseractOCRiOS.podspec
@@ -13,16 +13,16 @@ Pod::Spec.new do |s|
   s.authors                 = { 'Daniele Galiotto' => 'genius@g8production.com',
                                 'Kevin Conley' => 'kcon@stanford.edu'}
 
-  s.source                  = { :git => 'https://github.com/gali8/Tesseract-OCR-iOS.git',                                                         :tag => s.version.to_s }
+  #s.source                  = { :git => 'https://github.com/gali8/Tesseract-OCR-iOS.git',                                                         :tag => s.version.to_s }
 
-  s.platform                = :ios, "7.0"
-  s.source_files            = 'TesseractOCR/*.h', 'TesseractOCR/include/**/*.h'
+  s.platform                = :ios, "8.1"
+  s.source_files            = 'TesseractOCR/*.{h,m,mm}', 'TesseractOCR/include/**/*.h'
+  s.private_header_files    = 'TesseractOCR/include/**/*.h'
   s.requires_arc            = true
   s.frameworks              = 'UIKit', 'Foundation'
 
-  s.ios.deployment_target   = "7.0"
+  s.ios.deployment_target   = "8.0"
   s.ios.vendored_library    = 'TesseractOCR/lib/*.a'
-  s.ios.vendored_frameworks = 'Products/TesseractOCR.framework'
   s.xcconfig                = { 'OTHER_LDFLAGS' => '-lstdc++ -weak_library /usr/lib/libstdc++.6.0.9.dylib',
                                 'CLANG_CXX_LIBRARY' => 'compiler-default' }
 

--- a/TesseractOCRiOS.podspec
+++ b/TesseractOCRiOS.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.authors                 = { 'Daniele Galiotto' => 'genius@g8production.com',
                                 'Kevin Conley' => 'kcon@stanford.edu'}
 
-  #s.source                  = { :git => 'https://github.com/gali8/Tesseract-OCR-iOS.git',                                                         :tag => s.version.to_s }
+  s.source                  = { :git => 'https://github.com/gali8/Tesseract-OCR-iOS.git',                                                         :tag => s.version.to_s }
 
   s.platform                = :ios, "8.1"
   s.source_files            = 'TesseractOCR/*.{h,m,mm}', 'TesseractOCR/include/**/*.h'


### PR DESCRIPTION
See my note in the pull request on gali8/Tesseract-OCR-iOS#120.
